### PR TITLE
Removed deprecated gulp-util. Used instead plugin-error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 var through = require('through2');
-var gutil = require('gulp-util');
 var terser = require('terser');
+var PluginError = require('plugin-error');
 
-var PluginError = gutil.PluginError;
 var PLUGIN_NAME = 'terser';
 
 function gulpUglifyes(option){

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "url": "https://github.com/duan602728596"
   },
   "dependencies": {
-    "gulp-util": "^3.0.8",
-    "through2": "^2.0.3",
-    "terser": "^3.7.5"
+    "plugin-error": "^1.0.1",
+    "terser": "^3.7.5",
+    "through2": "^2.0.3"
   },
   "devDependencies": {
     "assert": "^1.4.1",


### PR DESCRIPTION
The change was made following the recommendations made here:

https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5