### PR TITLE
Properly handles promise rejection from terser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,9 @@ function gulpTerser(defaultOption: Object = {}, minify: Function | undefined): F
             setContents(result);
 
             return Promise.resolve(callback());
+          }).catch((err: Error): void => {
+            this.emit('error', new PluginError(PLUGIN_NAME, err));
+            return callback();
           });
         } else {
           setContents(resultPromise);


### PR DESCRIPTION
This change adds `Promise` rejection handler, preventing any minification error by terser from throwing `UnhandledPromiseRejectionWarning` and breaking-up gulp tasks.